### PR TITLE
Added new model configurations for 'yarn-mistral' and 'deepseek-coder'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Follow the installation instructions in the [Getting Started](https://unsaged.co
   - openchat
   - orca-mini
   - vicuna
+  - deepseek-coder-1b, deepseek-coder-6.7b, deepseek-coder-33b
 
 ## 🚀 Upgrading unSAGED
 

--- a/packages/unsaged/types/ai-models.ts
+++ b/packages/unsaged/types/ai-models.ts
@@ -271,6 +271,34 @@ export const PossibleAiModels: PossibleAiModelsInterface = {
     requestLimit: 3000,
     vendor: 'Ollama',
   },
+  'yarn-mistral:7b-128k': {
+    id: 'yarn-mistral:7b-128k',
+    maxLength: 128000,
+    tokenLimit: 4096,
+    requestLimit: 3000,
+    vendor: 'Ollama',
+  },  
+  'deepseek-coder:latest': {
+    id: 'deepseek-coder:latest',
+    maxLength: 16000,
+    tokenLimit: 4096,
+    requestLimit: 3000,
+    vendor: 'Ollama',
+  }, 
+  'deepseek-coder:6.7b': {
+    id: 'deepseek-coder:6.7b',
+    maxLength: 16000,
+    tokenLimit: 4096,
+    requestLimit: 3000,
+    vendor: 'Ollama',
+  }, 
+  'deepseek-coder:33b': {
+    id: 'deepseek-coder:33b',
+    maxLength: 16000,
+    tokenLimit: 4096,
+    requestLimit: 3000,
+    vendor: 'Ollama',
+  },      
   //
   // Ollama - Custom Models
   //


### PR DESCRIPTION
This commit introduces the following model configurations to the existing model registry:

- **yarn-mistral:7b-128k**
  - `id`: `yarn-mistral:7b-128k`
  - `maxLength`: 128000 tokens
  - `tokenLimit`: 4096 tokens per request
  - `requestLimit`: 3000 requests per client
  - `vendor`: `Ollama`

- **deepseek-coder:latest**
  - `id`: `deepseek-coder:latest`
  - `maxLength`: 16000 tokens
  - `tokenLimit`: 4096 tokens per request
  - `requestLimit`: 3000 requests per client
  - `vendor`: `Ollama`

- **deepseek-coder:6.7b**
  - `id`: `deepseek-coder:6.7b`
  - `maxLength`: 16000 tokens
  - `tokenLimit`: 4096 tokens per request
  - `requestLimit`: 3000 requests per client
  - `vendor`: `Ollama`

- **deepseek-coder:33b**
  - `id`: `deepseek-coder:33b`
  - `maxLength`: 16000 tokens
  - `tokenLimit`: 4096 tokens per request
  - `requestLimit`: 3000 requests per client
  - `vendor`: `Ollama`

These configurations have been validated and are ready for integration into the production environment